### PR TITLE
ContainerBasedJavaApplicationBuilder now don't lost unchecked Exception

### DIFF
--- a/oracle-tools-core/src/main/java/com/oracle/tools/deferred/listener/DeferredCompletionListener.java
+++ b/oracle-tools-core/src/main/java/com/oracle/tools/deferred/listener/DeferredCompletionListener.java
@@ -53,10 +53,10 @@ public class DeferredCompletionListener<T> implements Deferred<T>, CompletionLis
     private T result;
 
     /**
-     * The {@link Exception} as provided by the {@link CompletionListener}.
+     * The {@link Throwable} as provided by the {@link CompletionListener}.
      * (null if no exception was raised)
      */
-    private Exception exception;
+    private Throwable exception;
 
     /**
      * A flag indicating if the {@link CompletionListener} has been
@@ -98,7 +98,7 @@ public class DeferredCompletionListener<T> implements Deferred<T>, CompletionLis
 
 
     @Override
-    public void onException(Exception exception)
+    public void onException(Throwable exception)
     {
         synchronized (this)
         {

--- a/oracle-tools-core/src/main/java/com/oracle/tools/util/ExceptionListener.java
+++ b/oracle-tools-core/src/main/java/com/oracle/tools/util/ExceptionListener.java
@@ -26,7 +26,7 @@
 package com.oracle.tools.util;
 
 /**
- * A listener to be called when an {@link Exception} occurs during
+ * A listener to be called when an {@link Throwable} occurs during
  * some operation.
  * <p>
  * Copyright (c) 2013. All Rights Reserved. Oracle Corporation.<br>
@@ -37,9 +37,9 @@ package com.oracle.tools.util;
 public interface ExceptionListener
 {
     /**
-     * Called when an operation failed and raised an {@link Exception}.
+     * Called when an operation failed and raised an {@link Throwable}.
      *
-     * @param exception  the {@link Exception}
+     * @param exception  the {@link Throwable}
      */
-    public void onException(Exception exception);
+    public void onException(Throwable exception);
 }

--- a/oracle-tools-core/src/main/java/com/oracle/tools/util/FutureCompletionListener.java
+++ b/oracle-tools-core/src/main/java/com/oracle/tools/util/FutureCompletionListener.java
@@ -53,7 +53,7 @@ public class FutureCompletionListener<T> implements CompletionListener<T>, Futur
     /**
      * The exception (null if there was no exception).
      */
-    private Exception exception;
+    private Throwable exception;
 
 
     /**
@@ -89,7 +89,7 @@ public class FutureCompletionListener<T> implements CompletionListener<T>, Futur
 
 
     @Override
-    public void onException(Exception exception)
+    public void onException(Throwable exception)
     {
         synchronized (this)
         {

--- a/oracle-tools-runtime/src/main/java/com/oracle/tools/runtime/java/ContainerBasedJavaApplicationBuilder.java
+++ b/oracle-tools-runtime/src/main/java/com/oracle/tools/runtime/java/ContainerBasedJavaApplicationBuilder.java
@@ -612,7 +612,7 @@ public class ContainerBasedJavaApplicationBuilder<A extends JavaApplication>
                                                                                           originalClassLoader));
                                 }
                             }
-                            catch (Exception e)
+                            catch (Throwable e)
                             {
                                 // TODO: write the exception to the platform (if diagnostics are on?)
 


### PR DESCRIPTION
Before this change SimpleJavaApplication terminates on any unchecked exeception (like java.lang.Error) with uncompleted container's Future object.

This unchecked exception is catched internally by ThreadPoolExecutor and set to task's FutureTask. But this task's FutureTask object is never used. As result SimpleJavaApplication is terminates silently without any log messages.